### PR TITLE
release: Remove deprecated `dev-version` field, document workspace workaround and how to make GitHub releases

### DIFF
--- a/crate_release_strategy.md
+++ b/crate_release_strategy.md
@@ -13,7 +13,6 @@ We use [cargo-release](https://github.com/crate-ci/cargo-release) to help us bum
 `release.toml`:
 ```toml
 pre-release-commit-message = "Release {{version}}"
-dev-version = false
 tag-message = "Release {{version}}"
 tag-name = "{{version}}"
 sign-commit = true
@@ -25,13 +24,30 @@ pre-release-replacements = [
 ]
 ```
 
+If your crate consists of a `[workspace]` with multiple crates, but you only wish to publish the root crate or keep all crate versions in sync, add the following configuration to make sure `cargo-release` substitutes `{{version}}` in the templates above:
+
+```toml
+# cargo-release only allows using {{version}} in the commit title when creating one
+# commit across all released packages in this workspace (we only release one package
+# though), or by using the same version for all packages.
+# https://github.com/crate-ci/cargo-release/issues/540#issuecomment-1328769105
+# https://github.com/crate-ci/cargo-release/commit/3af94caa4b9bbee010a5cf3f196cc4afffbaf192
+consolidate-commits = false
+shared-version = true
+```
+
 With that, a developer performs a release on their local machine with:
 
 ```console
+$ cargo install cargo-release
 $ cargo release "<next version>"
 ```
 
 (Only add `-x` if you are okay with the changes!)
+
+#### Creating a release on GitHub
+
+While [the CI process](###the-automated-ci-process) runs, click `Draft a new release` on the `releases` page on GitHub. Select the tag matching the version just pushed by `cargo-release` above, and click `Generate release notes` to automatically populate the title and description. Modify both as necessary. In particular, release notes convey user-facing changes: remove internal changes such as clippy fixes and other cleanups. When breaking changes are made or new features are added, spend an extra paragraph at the top detailing how users should migrate to or make use of the new release 🥳!
 
 ### The automated CI process
 


### PR DESCRIPTION
This doc is slowly shifting from a guide to initially set up the release strategy/workflow (with copyable snippets) to providing a guide on how to use it!
